### PR TITLE
Update ionic-monthpicker.factory.js

### DIFF
--- a/src/ionic-monthpicker.factory.js
+++ b/src/ionic-monthpicker.factory.js
@@ -17,7 +17,7 @@
                 //
                 scope.minMonthIndex = options.minMonthIndex || 0;
                 scope.minYear = options.minYear || new Date().getFullYear();
-                scope.maxMonthIndex = options.maxMonthIndex || new Date().getMonth();
+                scope.maxMonthIndex = options.maxMonthIndex === undefined?new Date().getMonth():options.maxMonthIndex;;
                 scope.maxYear = options.maxYear || new Date().getFullYear();
 
                 scope.monthLabels = options.monthLabels || ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];


### PR DESCRIPTION
fix max month if month is January - id=0 resulting in current month as first month